### PR TITLE
Bruk interne fil-lenker i stedet for URL-lenker

### DIFF
--- a/docs/nettadministrasjon/brukerdok.md
+++ b/docs/nettadministrasjon/brukerdok.md
@@ -33,7 +33,7 @@ merkbare driftsforstyrrelser.
 ## Sikkerhetsdirektiv for verktøykassene
 
 Sikt har driftsansvar for verktøykassene, se definert
-[sikkerhetsdirektiv](sikkerhetsdirektiv) for detaljer rundt drift-
+[sikkerhetsdirektiv](sikkerhetsdirektiv.md) for detaljer rundt drift-
 og sikkerhetsopplegget.
 
 Siden driftsansvaret ligger til Sikt er ryddigste løsning at *kun* Sikt
@@ -518,9 +518,9 @@ følger en liste og kort omtale:
 
 ## Hobbit/Xymon
 
-Se egen side for [dokumentasjon av Xymon-integrasjonen på verktøykassen](xymon).
+Se egen side for [dokumentasjon av Xymon-integrasjonen på verktøykassen](xymon.md).
 
 ## Firewall Builder (fwbuilder)
 
 [Brukerdokumentasjon for Firewall Builder foreligger på en egen
-side](fwbuilder).
+side](fwbuilder.md).


### PR DESCRIPTION
For å unngå rot med "trailing slashes" og relative lenker som potensielt
brekker må man lenke til interne sider ved filnavn, for at Docusaurus
skal prosessere dem riktig.