### PR TITLE
Fix indentation in educsc sidebars.js

### DIFF
--- a/docs/educsc/sidebars.js
+++ b/docs/educsc/sidebars.js
@@ -1,4 +1,4 @@
 module.exports = [
-    'educsc/index',
-  ];
+  'educsc/index',
+];
   


### PR DESCRIPTION
Too many indentations was causing the 'Lint and build' check to fail.

As seen in this PR: https://github.com/sikt-no/docs/actions/runs/5390708618/jobs/9786468310?pr=113